### PR TITLE
768 - Create and deploy new release deployment cluster

### DIFF
--- a/third-party/Chart.yaml
+++ b/third-party/Chart.yaml
@@ -12,9 +12,6 @@ dependencies:
   - name: cert-manager
     version: 1.8.2
     repository: "https://charts.jetstack.io"
-  - name: external-secrets
-    version: 0.7.2
-    repository: https://charts.external-secrets.io
   - name: ingress-nginx
     version: 4.2.0
     repository: "https://kubernetes.github.io/ingress-nginx"


### PR DESCRIPTION
Because we've moved the external-secrets-gsm helm chart to third party, it means that external-secrets has to already exist, so adding it as a dependency to the external-secrets-gsm package means it should get installed first

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/768