### PR TITLE
935: Workflow changes based on feedback from release 1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ publish_helm:
 ifndef name
 	$(error A name must be supplied, Eg. make package_helm name=external-secrets-gsm-0.9.0.tgz)
 endif
-	jf rt upload  ./${name} ${helm_repo}
+	jf rt upload  ./${name} ${helm_repo} || echo "Error uploading ${name}"


### PR DESCRIPTION
Update makefile for publish_helm to echo a general error message if uploading to repository fails

We need this as without if a package already exists the pipeline will fail, instead of trying to upload the other packages where there may be changes to upload