### PR TITLE
969: Increment versions to be deployed for 1.0.1 Helm Package release

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/kustomization.yaml
+++ b/kustomize/overlay/7.2.0/defaults/kustomization.yaml
@@ -14,8 +14,7 @@ patchesStrategicMerge:
 images:
 - name: ig
   newName: eu.gcr.io/sbat-gcr-release/securebanking/gate/ig
-  # Will need changing
-  newTag: 1.0.0
+  newTag: 1.0.1
   
   
   

--- a/secure-api-gateway-helpers/Chart.yaml
+++ b/secure-api-gateway-helpers/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: secure-api-gateway-helpers
 description: Helm chart for deploying optional third party sources for secure-api-gateway to kubernetes cluster
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 
 dependencies:
   - name: external-secrets-gsm

--- a/secure-api-gateway/Chart.yaml
+++ b/secure-api-gateway/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: secure-api-gateway
 description: Helm chart for deploying the secure-api-gateway to kubernetes cluster
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 
 dependencies:
   - name: remote-consent-service
-    version: 1.0.0
+    version: 1.0.1
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 1.0.0
+    version: 1.0.1
     repository: "@forgerock-helm"
   - name: test-user-account-creator
     version: 1.0.0
     repository: "@forgerock-helm"
   - name: remote-consent-service-user-interface
-    version: 1.0.1
+    version: 1.0.2
     repository: "@forgerock-helm"

--- a/third-party/Chart.yaml
+++ b/third-party/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: third-party
 description: Helm chart for deploying the third party sources required for the secure-api-gateway to kubernetes cluster
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 
 dependencies:
   - name: mongodb


### PR DESCRIPTION
Specify what versions of the child items will be used for version 1.0.1 of the secure-api-gateway helm umbrella charts.

Secure API Gateway: 1.0.0 > 1.0.1
IG: 1.0.0 > 1.0.1
remote-consent-service: 1.0.0 > 1.0.1
test-facility-bank: 1.0.0 > 1.0.1
remote-consent-service-user-interface: 1.0.1 > 1.0.2

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/969

Releases

- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk/pull/383 
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/pull/173
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/128
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/129
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-ui/pull/96
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-ui/pull/97
- https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-functional-tests/pull/123