### PR TITLE
990 ob sandbox v1 replicas

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/deployment.yaml
+++ b/kustomize/overlay/7.2.0/defaults/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: ig
 spec:
+  replicas: 1
   template:
     spec:
       initContainers:

--- a/kustomize/overlay/7.2.0/defaults/deployment.yaml
+++ b/kustomize/overlay/7.2.0/defaults/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: ig
 spec:
-  replicas: 1
+  replicas: 3
   template:
     spec:
       initContainers:


### PR DESCRIPTION
Increase IG replicas to 3 for scalability

Tag 1.0.2-prerelease has been created with these changes, so that ob-sandbox-v1 can be updated without an official release

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/990