### PR TITLE
995: sapig release 1.0.2

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/deployment.yaml
+++ b/kustomize/overlay/7.2.0/defaults/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: ig
 spec:
+  replicas: 3
   template:
     spec:
       initContainers:

--- a/kustomize/overlay/7.2.0/defaults/kustomization.yaml
+++ b/kustomize/overlay/7.2.0/defaults/kustomization.yaml
@@ -14,7 +14,7 @@ patchesStrategicMerge:
 images:
 - name: ig
   newName: eu.gcr.io/sbat-gcr-release/securebanking/gate/ig
-  newTag: 1.0.1
-  
+  newTag: 1.0.2
+
   
   

--- a/secure-api-gateway/Chart.yaml
+++ b/secure-api-gateway/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: secure-api-gateway
 description: Helm chart for deploying the secure-api-gateway to kubernetes cluster
 type: application
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.0.2
+appVersion: 1.0.2
 
 dependencies:
   - name: remote-consent-service
-    version: 1.0.1
+    version: 1.0.2
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 1.0.1
+    version: 1.0.2
     repository: "@forgerock-helm"
   - name: test-user-account-creator
     version: 1.0.0
     repository: "@forgerock-helm"
   - name: remote-consent-service-user-interface
-    version: 1.0.2
+    version: 1.0.3
     repository: "@forgerock-helm"


### PR DESCRIPTION
- Updated deployment so that IG has 3 replicas 
- Changed kustomization.yaml so that version 1.0.2 is used for IG
- Updated child values in umbrella chart to pick up new changes

Deployment: https://github.com/SecureApiGateway/SecureApiGateway/issues/995