### PR TITLE
918: Update annotations for nginx

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/ingress.yaml
+++ b/kustomize/overlay/7.2.0/defaults/ingress.yaml
@@ -7,8 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -53,8 +52,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -109,8 +107,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
     nginx.ingress.kubernetes.io/auth-tls-secret: $(NAMESPACE)/obri-ca
     nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
-    nginx.ingress.kubernetes.io/http2-max-field-size: 16k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 128k
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
     nginx.ingress.kubernetes.io/proxy-body-size: 64m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/proxy-buffering: "on"


### PR DESCRIPTION
Change `http2-max-header-size` to `large-client-header-buffers` & remove obsolete `http2-max-field-size`

This will tie in with the update from nginx 4.2.0 -> 4.8.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/918