### PR TITLE
1148: prepare release 2.1.0

### DIFF
--- a/kustomize/overlay/7.2.0/defaults/kustomization.yaml
+++ b/kustomize/overlay/7.2.0/defaults/kustomization.yaml
@@ -14,4 +14,4 @@ patchesStrategicMerge:
 images:
 - name: ig
   newName: eu.gcr.io/sbat-gcr-release/securebanking/gate/ig
-  newTag: 2.0.0
+  newTag: 2.1.0

--- a/secure-api-gateway/Chart.yaml
+++ b/secure-api-gateway/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: secure-api-gateway
 description: Helm chart for deploying the secure-api-gateway to kubernetes cluster
 type: application
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.1.0
+appVersion: 2.1.0
 
 dependencies:
   - name: remote-consent-service
-    version: 2.0.2
+    version: 2.1.0
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 2.0.2
+    version: 2.1.0
     repository: "@forgerock-helm"
   - name: test-user-account-creator
     version: 2.0.0
     repository: "@forgerock-helm"
   - name: remote-consent-service-user-interface
-    version: 2.0.0
+    version: 2.1.0
     repository: "@forgerock-helm"


### PR DESCRIPTION
- Updated ig tag to 2.1.0
- Updated sapig charts to 2.1.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1148