### PR TITLE
1260: Release PR Workflows Run

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,14 @@
+name: Pull Request - Build and Deploy
+
+on:
+  pull_request:
+    branches:
+      - master
+
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Check PR
+    steps:
+      - uses: actions/checkout@v4

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,0 +1,30 @@
+name: create-release
+run-name: Create release '${{ inputs.release_version_number }}'
+# What it does:
+# - Call release-prepare-no-maven
+# - package_and_publish_helm
+# - Call release-publish-draft-and-pr: create pr false
+on:
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Release notes"
+        required: false
+        type: string
+        default: ''
+      release_version_number:
+        description: "Provide release version number"
+        required: true
+        type: string
+
+jobs:
+  release_draft:
+    name: Call publish release draft
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-draft-and-pr.yml@master
+    with:
+      release_version_number: ${{ inputs.release_version_number }}
+      release_branch_ref: ${{ needs.release_prepare_no_maven.outputs.release_branch_ref }}
+      release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
+      release_notes: ${{ inputs.notes }}
+      create_pr: true
+      github_token: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
As per [this link](https://github.com/orgs/community/discussions/25702) by default workflows that are called from another repository won't initiate any actions with the default PAT Token. 

I've created a PAT Token for the github actions user, added it as a organisation secret to test if the link is correct and if the actions will then run. 

This would then stop us from needing to add a empty commit to the generated PR. 

NOTE: This may be redundant as we are thinking we may not need the whole PR process but this is a first step in case we want to keep it 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1260