### PR TITLE
1313: Update Repos for having Core and OB SAPIG

### DIFF
--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: secure-api-gateway-ob
 description: Helm chart for deploying the secure-api-gateway OB edition to kubernetes cluster
 type: application
-version: 2.3.1
-appVersion: 2.3.1
+version: 2.4.0
+appVersion: 2.4.0
 
 dependencies:
   - name: remote-consent-service


### PR DESCRIPTION
Bump OB Chart version to 2.4.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1313