### PR TITLE
1404: Only add openbanking_intent_id claim for OB flow

### DIFF
--- a/postman/v2.0/postman_scripts/client_jws_helpers.js
+++ b/postman/v2.0/postman_scripts/client_jws_helpers.js
@@ -140,10 +140,6 @@ client_jws_helpers.createAuthorizeJwtData = function(scope, consentId, jarm) {
               "acr": {
               "value": acr,
               "essential": true
-            },
-            "openbanking_intent_id": {
-              "value": consentId,
-              "essential": true
             }
           }
         },
@@ -152,6 +148,13 @@ client_jws_helpers.createAuthorizeJwtData = function(scope, consentId, jarm) {
         "state": "10d260bf-a7d9-444a-92d9-7b7a5f088208",
         "nonce": "10d260bf-a7d9-444a-92d9-7b7a5f088208",
         "client_id": pm.environment.get("client_id")
+    }
+
+    if (acr.includes("openbanking")) {
+        data.claims["openbanking_intent_id"] = {
+            "value": consentId,
+            "essential": true
+        }
     }
 
     if (jarm) {


### PR DESCRIPTION
Adding this claim for non-OB flows causes issues, as the claim is not supported by the AM OAuth 2.0 Provider.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1404