### PR TITLE
1452: Investigate relenvs v3 keystore issue

### DIFF
--- a/secure-api-gateway-helpers/Chart.yaml
+++ b/secure-api-gateway-helpers/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: secure-api-gateway-helpers
 description: Helm chart for deploying optional third party sources for secure-api-gateway to kubernetes cluster
 type: application
-version: 3.0.0
-appVersion: 3.0.0
+version: 3.0.1
+appVersion: 3.0.1
 
 dependencies:
   - name: external-secrets-gsm
-    version: 3.0.0
+    version: 3.0.1
     repository: "@forgerock-helm"


### PR DESCRIPTION
Bump helpers version to 3.0.1 to pick up bug fix from [PR](https://github.com/SecureApiGateway/secure-api-gateway-releases-helpers/pull/18)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1452