### PR TITLE
1451: v3 Postman fixes

### DIFF
--- a/postman/v3.0/collections/Secure API Gateway - Open Banking UK TPP Flows.postman_collection.json
+++ b/postman/v3.0/collections/Secure API Gateway - Open Banking UK TPP Flows.postman_collection.json
@@ -81,7 +81,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://raw.githubusercontent.com/SecureApiGateway/secure-api-gateway-releases/v3.0.1/postman/v3.0/postman_scripts/client_jws_helpers.js",
+							"raw": "https://raw.githubusercontent.com/SecureApiGateway/secure-api-gateway-releases/v3.0.2/postman/v3.0/postman_scripts/client_jws_helpers.js",
 							"protocol": "https",
 							"host": [
 								"raw",
@@ -91,7 +91,7 @@
 							"path": [
 								"SecureApiGateway",
 								"secure-api-gateway-releases",
-								"v3.0.1",
+								"v3.0.2",
 								"postman",
 								"v3.0",
 								"postman_scripts",

--- a/postman/v3.0/collections/Secure API Gateway - Open Banking UK TPP Flows.postman_collection.json
+++ b/postman/v3.0/collections/Secure API Gateway - Open Banking UK TPP Flows.postman_collection.json
@@ -91,9 +91,9 @@
 							"path": [
 								"SecureApiGateway",
 								"secure-api-gateway-releases",
-								"master",
+								"v3.0.1",
 								"postman",
-								"v2.0",
+								"v3.0",
 								"postman_scripts",
 								"client_jws_helpers.js"
 							]

--- a/postman/v3.0/collections/Secure API Gateway - Plain FAPI.postman_collection.json
+++ b/postman/v3.0/collections/Secure API Gateway - Plain FAPI.postman_collection.json
@@ -81,7 +81,7 @@
 							}
 						],
 						"url": {
-							"raw": "https://raw.githubusercontent.com/SecureApiGateway/secure-api-gateway-releases/v3.0.1/postman/v3.0/postman_scripts/client_jws_helpers.js",
+							"raw": "https://raw.githubusercontent.com/SecureApiGateway/secure-api-gateway-releases/v3.0.2/postman/v3.0/postman_scripts/client_jws_helpers.js",
 							"protocol": "https",
 							"host": [
 								"raw",
@@ -91,7 +91,7 @@
 							"path": [
 								"SecureApiGateway",
 								"secure-api-gateway-releases",
-								"v3.0.1",
+								"v3.0.2",
 								"postman",
 								"v3.0",
 								"postman_scripts",

--- a/postman/v3.0/collections/Secure API Gateway - Plain FAPI.postman_collection.json
+++ b/postman/v3.0/collections/Secure API Gateway - Plain FAPI.postman_collection.json
@@ -91,9 +91,9 @@
 							"path": [
 								"SecureApiGateway",
 								"secure-api-gateway-releases",
-								"master",
+								"v3.0.1",
 								"postman",
-								"v2.0",
+								"v3.0",
 								"postman_scripts",
 								"client_jws_helpers.js"
 							]

--- a/postman/v3.0/postman_scripts/client_jws_helpers.js
+++ b/postman/v3.0/postman_scripts/client_jws_helpers.js
@@ -130,18 +130,18 @@ client_jws_helpers.createAuthorizeJwtData = function(scope, consentId, jarm) {
     let acr = pm.environment.has("AUTHORIZE_REQUEST_ACR") ? pm.environment.get("AUTHORIZE_REQUEST_ACR") : "urn:openbanking:psd2:ca"
 
     var data = {
-          "aud": audience,
-          "scope": scope,
-          "iss": pm.environment.get("client_id"),
-          "exp": exp,
-          "nbf": nbf,
-          "claims": {
+        "aud": audience,
+        "scope": scope,
+        "iss": pm.environment.get("client_id"),
+        "exp": exp,
+        "nbf": nbf,
+        "claims": {
             "id_token": {
-              "acr": {
-              "value": acr,
-              "essential": true
+                "acr": {
+                    "value": acr,
+                    "essential": true
+                }
             }
-          }
         },
         "response_type": "code id_token",
         "redirect_uri": pm.environment.get("client_redirect_uri"),
@@ -151,7 +151,7 @@ client_jws_helpers.createAuthorizeJwtData = function(scope, consentId, jarm) {
     }
 
     if (acr.includes("openbanking")) {
-        data.claims["openbanking_intent_id"] = {
+        data.claims.id_token["openbanking_intent_id"] = {
             "value": consentId,
             "essential": true
         }


### PR DESCRIPTION
Fix the path to client_jws_helpers.js used by v3 collections & bump version to 3.0.2 (which will be released next).

Apply fix:
https://github.com/SecureApiGateway/secure-api-gateway-releases/pull/65 to the v3.0 client_jws_helpers.js

https://github.com/SecureApiGateway/SecureApiGateway/issues/1451