### PR TITLE
1476: Build and Deploy SAPIG 3.1.0 to relenv

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/securebanking/kustomization.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/securebanking/kustomization.yaml
@@ -9,6 +9,6 @@ labels:
 namespace: sandbox
 resources:
 # May need a nicer way of doing the release version in future
-- https://github.com/ForgeRock/forgeops/kustomize/base/ig?ref=release/7.5-20240402
+- https://github.com/ForgeRock/forgeops/kustomize/base/ig?ref=release/7.5-20240618
 secretGenerator:
   - name: core-secrets

--- a/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
+++ b/ob/kustomize/overlay/7.3.0/defaults/kustomization.yaml
@@ -36,7 +36,7 @@ patches:
       metadata:
         name: openig-secrets-env
 resources:
-  - https://github.com/SecureApiGateway/secure-api-gateway-releases/core/kustomize/overlay/7.3.0/defaults?ref=v3.1.0-RC
+  - https://github.com/SecureApiGateway/secure-api-gateway-releases/core/kustomize/overlay/7.3.0/defaults?ref=v3.1.0
   - ingress.yaml
 secretGenerator:
   - name: ob-secrets

--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: secure-api-gateway-ob
 description: Helm chart for deploying the secure-api-gateway OB edition to kubernetes cluster
 type: application
-version: 3.0.1
-appVersion: 3.0.1
+version: 3.1.0
+appVersion: 3.1.0
 
 dependencies:
   - name: remote-consent-service
-    version: 3.0.0
+    version: 3.1.0
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 3.0.1
+    version: 3.1.0
     repository: "@forgerock-helm"
   - name: test-user-account-creator
     version: 3.0.1
     repository: "@forgerock-helm"
   - name: remote-consent-service-user-interface
-    version: 3.0.0
+    version: 3.1.0
     repository: "@forgerock-helm"


### PR DESCRIPTION
Update Kustomize to use newest 20240618 branch of forgeops
Remove RC from ob tag to use for kustomize
Update OB Umbrella charts to use `3.1.0`

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1476