### PR TITLE
1476: Build and Deploy SAPIG 3.1.0 to relenv

### DIFF
--- a/test-trusted-directory/kustomize/defaults/kustomization.yaml
+++ b/test-trusted-directory/kustomize/defaults/kustomization.yaml
@@ -1,9 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-images:
-  - name: testdirectory
-    newName: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-test-trusted-directory
-    newTag: latest
 labels:
   - includeSelectors: true
     pairs:


### PR DESCRIPTION
Remove image override as done in deployments repo

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1476