### PR TITLE
1512: SAPI-G ingress pass all traffic to ig pod

### DIFF
--- a/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
+++ b/core/kustomize/overlay/7.3.0/defaults/ingress.yaml
@@ -80,7 +80,7 @@ spec:
                 name: ig
                 port:
                   number: 80
-            path: /am/
+            path: /
             pathType: Prefix
   tls:
     - hosts:

--- a/secure-api-gateway-helpers/Chart.yaml
+++ b/secure-api-gateway-helpers/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: secure-api-gateway-helpers
 description: Helm chart for deploying optional third party sources for secure-api-gateway to kubernetes cluster
 type: application
-version: 3.0.1
-appVersion: 3.0.1
+version: 3.1.2
+appVersion: 3.1.2
 
 dependencies:
   - name: external-secrets-gsm
-    version: 3.0.1
+    version: 3.1.2
     repository: "@forgerock-helm"

--- a/secure-api-gateway-helpers/Chart.yaml
+++ b/secure-api-gateway-helpers/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: secure-api-gateway-helpers
 description: Helm chart for deploying optional third party sources for secure-api-gateway to kubernetes cluster
 type: application
-version: 3.1.2
-appVersion: 3.1.2
+version: 3.0.1
+appVersion: 3.0.1
 
 dependencies:
   - name: external-secrets-gsm
-    version: 3.1.2
+    version: 3.0.1
     repository: "@forgerock-helm"


### PR DESCRIPTION
All traffic which does not match a more specific rule is now routed to the IG pod. This allows us to reverse proxy identity platform without having to know all of the possible paths that might need to be accessed.

See related IG PR: https://github.com/SecureApiGateway/secure-api-gateway-core/pull/65

https://github.com/SecureApiGateway/SecureApiGateway/issues/1512