### PR TITLE
1665: Update secure-api-gateway-release with changes from Forgeops 

### DIFF
--- a/ob/kustomize/base/kustomization.yaml
+++ b/ob/kustomize/base/kustomization.yaml
@@ -24,6 +24,6 @@ patches:
       name: core-deployment-config
     path: patch/configmap/core-configmap-patch.yaml
 resources:
-  - https://github.com/SecureApiGateway/secure-api-gateway-releases/core/kustomize/base?ref=v4.0.4
+  - https://github.com/SecureApiGateway/secure-api-gateway-releases/core/kustomize/base?ref=v4.0.6
 secretGenerator:
   - name: ob-secrets


### PR DESCRIPTION
Update OB to use the new release version of release branch

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1665