### PR TITLE
1682: Use new Helm files to deploy to Relenv

### DIFF
--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -13,16 +13,16 @@ dependencies:
     version: 4.9.0
     repository: "@forgerock-helm"
   - name: remote-consent-service
-    version: 4.0.4
+    version: 4.9.0
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 4.0.5
+    version: 4.9.0
     repository: "@forgerock-helm"
   - name: test-user-account-creator
-    version: 4.0.0
+    version: 4.9.0
     repository: "@forgerock-helm"
   - name: remote-consent-service-user-interface
-    version: 4.0.5
+    version: 4.9.0
     repository: "@forgerock-helm"
   - name: test-trusted-directory
     version: 4.9.0


### PR DESCRIPTION
Bump components to 4.9.0 for test release

Issue: https://github.com/secureapigateway/secureapigateway/issues/1682