### PR TITLE
openIG-9573: SAPIG 5.0.1 Release

### DIFF
--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -2,15 +2,15 @@ apiVersion: v2
 name: secure-api-gateway-ob
 description: Helm chart for deploying the secure-api-gateway OB edition to kubernetes cluster
 type: application
-version: 5.0.0
-appVersion: 5.0.0
+version: 5.0.1
+appVersion: 5.0.1
 
 dependencies:
   - name: fapi-pep-as
-    version: 5.0.0
+    version: 5.0.1
     repository: "@forgerock-helm"
   - name: fapi-pep-rs-ob
-    version: 5.0.0
+    version: 5.0.1
     repository: "@forgerock-helm"
   - name: remote-consent-service
     version: 5.0.0


### PR DESCRIPTION
Bump ob fapi-pep-as and fapi-pep-rs to `5.0.1`

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9573?atlOrigin=eyJpIjoiY2MxNDI2YTRmY2E2NDE4NGFmYzU1ZTM2ZDgxZjlkMTAiLCJwIjoiaiJ9