### PR TITLE
OpenIG-9799: Backport changes from Fapi-pep-as V5.0.2 -> V5.0.5

### DIFF
--- a/core/secure-api-gateway-core/Chart.yaml
+++ b/core/secure-api-gateway-core/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 5.0.4
 
 dependencies:
   - name: fapi-pep-as
-    version: 5.0.4
+    version: 5.0.5
     repository: "@forgerock-helm"
   - name: fapi-pep-rs-core
     version: 5.0.4

--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 5.0.4
 
 dependencies:
   - name: fapi-pep-as
-    version: 5.0.4
+    version: 5.0.5
     repository: "@forgerock-helm"
   - name: fapi-pep-rs-ob
     version: 5.0.4


### PR DESCRIPTION
Create release with FAPI-PEP-AS 5.0.5

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9799?atlOrigin=eyJpIjoiOWJhMTA0ZmRlYzE4NDZhZWE0ODdkOTVjOWYyN2Y1YTIiLCJwIjoiaiJ9