### PR TITLE
OpenIG-9948: Allow some components to be conditional in parent chart

### DIFF
--- a/core/secure-api-gateway-core/Chart.yaml
+++ b/core/secure-api-gateway-core/Chart.yaml
@@ -15,3 +15,4 @@ dependencies:
   - name: test-trusted-directory
     version: 5.0.6
     repository: "@forgerock-helm"
+    condition: test-trusted-directory.enabled

--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -21,9 +21,11 @@ dependencies:
   - name: test-user-account-creator
     version: 5.0.6
     repository: "@forgerock-helm"
+    condition: test-user-account-creator.enabled
   - name: remote-consent-service-user-interface
     version: 5.0.6
     repository: "@forgerock-helm"
   - name: test-trusted-directory
     version: 5.0.6
     repository: "@forgerock-helm"
+    condition: test-trusted-directory.enabled


### PR DESCRIPTION
Allow some components to be conditional in parent chart

Controlled via values.yaml file for example;

```
test-trusted-directory:
  enabled: false <-- New Line for condition
  configmap:
    igTestDirectoryFQDN: "test-trusted-directory.ob-sandbox-v5.forgerock.financial"
```

Issue: https://pingidentity.atlassian.net/jira/software/c/projects/OPENIG/boards/1322?selectedIssue=OPENIG-9948