### PR TITLE
OPENIG-10328 Bump versions for SAPIG 5.2.0 release (IG 2026.3.0)

### DIFF
--- a/core/secure-api-gateway-core/Chart.yaml
+++ b/core/secure-api-gateway-core/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: secure-api-gateway-core
 description: Helm chart for deploying the secure-api-gateway CORE edition to kubernetes cluster
 type: application
-version: 5.1.1
-appVersion: 5.1.1
+version: 5.2.0
+appVersion: 5.2.0
 
 dependencies:
   - name: fapi-pep-as
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: fapi-pep-rs-core
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: test-trusted-directory
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
     condition: test-trusted-directory.enabled

--- a/ob/secure-api-gateway-ob/Chart.yaml
+++ b/ob/secure-api-gateway-ob/Chart.yaml
@@ -2,30 +2,30 @@ apiVersion: v2
 name: secure-api-gateway-ob
 description: Helm chart for deploying the secure-api-gateway OB edition to kubernetes cluster
 type: application
-version: 5.1.1
-appVersion: 5.1.1
+version: 5.2.0
+appVersion: 5.2.0
 
 dependencies:
   - name: fapi-pep-as
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: fapi-pep-rs-ob
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: remote-consent-service
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: test-facility-bank
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
   - name: test-user-account-creator
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
     condition: test-user-account-creator.enabled
   - name: remote-consent-service-user-interface
     version: 5.0.6
     repository: "@forgerock-helm"
   - name: test-trusted-directory
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"
     condition: test-trusted-directory.enabled

--- a/secure-api-gateway-helpers/Chart.yaml
+++ b/secure-api-gateway-helpers/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: secure-api-gateway-helpers
 description: Helm chart for deploying optional third party sources for secure-api-gateway to kubernetes cluster
 type: application
-version: 5.1.1
-appVersion: 5.1.1
+version: 5.2.0
+appVersion: 5.2.0
 
 dependencies:
   - name: external-secrets-gsm
-    version: 5.1.1
+    version: 5.2.0
     repository: "@forgerock-helm"

--- a/third-party/Chart.yaml
+++ b/third-party/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: third-party
 description: Helm chart for deploying the third party sources required for the secure-api-gateway to kubernetes cluster
 type: application
-version: 5.1.1
-appVersion: 5.1.1
+version: 5.2.0
+appVersion: 5.2.0
 
 dependencies:
   - name: mongodb


### PR DESCRIPTION
Bump all Helm chart versions to 5.2.0 for the SAPIG 5.2.0 release (IG 2026.3.0).

Note: `remote-consent-service-user-interface` intentionally stays on `5.0.6`.

After merge, trigger the release workflow from master:
- branch: `master`
- version: `5.2.0`
- release notes: `Release SAPIG 5.2.0 (IG 2026.3.0)`

Part of SAPIG 5.2.0 release (OPENIG-10328).